### PR TITLE
refactor: externalize frontmatter plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
   },
   "dependencies": {
     "@antfu/utils": "^0.5.2",
-    "@mdit-vue/plugin-component": "^0.1.1",
+    "@mdit-vue/plugin-component": "^0.6.0",
+    "@mdit-vue/plugin-frontmatter": "^0.6.0",
+    "@mdit-vue/types": "^0.6.0",
     "@rollup/pluginutils": "^4.2.1",
     "@types/markdown-it": "^12.2.3",
-    "gray-matter": "^4.0.3",
     "markdown-it": "^13.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   },
   "dependencies": {
     "@antfu/utils": "^0.5.2",
-    "@mdit-vue/plugin-component": "^0.6.0",
-    "@mdit-vue/plugin-frontmatter": "^0.6.0",
-    "@mdit-vue/types": "^0.6.0",
+    "@mdit-vue/plugin-component": "^0.7.0",
+    "@mdit-vue/plugin-frontmatter": "^0.7.0",
+    "@mdit-vue/types": "^0.7.0",
     "@rollup/pluginutils": "^4.2.1",
     "@types/markdown-it": "^12.2.3",
     "markdown-it": "^13.0.1"

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   },
   "dependencies": {
     "@antfu/utils": "^0.5.2",
-    "@mdit-vue/plugin-component": "^0.7.0",
-    "@mdit-vue/plugin-frontmatter": "^0.7.0",
-    "@mdit-vue/types": "^0.7.0",
+    "@mdit-vue/plugin-component": "^0.7.1",
+    "@mdit-vue/plugin-frontmatter": "^0.7.1",
+    "@mdit-vue/types": "^0.7.1",
     "@rollup/pluginutils": "^4.2.1",
     "@types/markdown-it": "^12.2.3",
     "markdown-it": "^13.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ importers:
       '@antfu/eslint-config': ^0.25.2
       '@antfu/ni': ^0.16.3
       '@antfu/utils': ^0.5.2
-      '@mdit-vue/plugin-component': ^0.6.0
-      '@mdit-vue/plugin-frontmatter': ^0.6.0
-      '@mdit-vue/types': ^0.6.0
+      '@mdit-vue/plugin-component': ^0.7.0
+      '@mdit-vue/plugin-frontmatter': ^0.7.0
+      '@mdit-vue/types': ^0.7.0
       '@rollup/pluginutils': ^4.2.1
       '@types/markdown-it': ^12.2.3
       '@types/node': ^18.0.0
@@ -24,9 +24,9 @@ importers:
       vitest: ^0.16.0
     dependencies:
       '@antfu/utils': 0.5.2
-      '@mdit-vue/plugin-component': 0.6.0
-      '@mdit-vue/plugin-frontmatter': 0.6.0
-      '@mdit-vue/types': 0.6.0
+      '@mdit-vue/plugin-component': 0.7.0
+      '@mdit-vue/plugin-frontmatter': 0.7.0
+      '@mdit-vue/types': 0.7.0
       '@rollup/pluginutils': 4.2.1
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
@@ -262,24 +262,24 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@mdit-vue/plugin-component/0.6.0:
-    resolution: {integrity: sha512-S/Dd0eoOipbUAMdJ6A7M20dDizJxbtGAcL6T1iiJ0cEzjTrHP1kRT421+JMGPL8gcdsrIxgVSW8bI/R6laqBtA==}
+  /@mdit-vue/plugin-component/0.7.0:
+    resolution: {integrity: sha512-XKH99MRI2mkwTsKVKjrs8i/r4LGTrdX8p80aaH3gE42erlRTu41DOWJZ57HP4TQhSsENhY01DUS+rJlKcnWKfQ==}
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
     dev: false
 
-  /@mdit-vue/plugin-frontmatter/0.6.0:
-    resolution: {integrity: sha512-cRunxy0q1gcqxUHAAiV8hMKh2qZOTDKXt8YOWfWNtf7IzaAL0v/nCOfh+O7AsHRmyc25Th8sL3H85HKWnNJtdw==}
+  /@mdit-vue/plugin-frontmatter/0.7.0:
+    resolution: {integrity: sha512-L7VOyilYkHM8lX/de0I3huXPvo6FpQnsM9irHloCjxFjGWjQGQPVgKwlmuUiEnoszP91bGOcFazRUuESonZIxg==}
     dependencies:
-      '@mdit-vue/types': 0.6.0
+      '@mdit-vue/types': 0.7.0
       '@types/markdown-it': 12.2.3
       gray-matter: 4.0.3
       markdown-it: 13.0.1
     dev: false
 
-  /@mdit-vue/types/0.6.0:
-    resolution: {integrity: sha512-2Gf6MkEmoHrvO/IJsz48T+Ns9lW17ReC1vdhtCUGSCv0fFCm/L613uu/hpUrHuT3jTQHP90LcbXTQB2w4L1G8w==}
+  /@mdit-vue/types/0.7.0:
+    resolution: {integrity: sha512-9OlHbqAtKFvQ8lxeXEcLpwVQMZnlVAzSmSQ4OtlWPGGLnSUFNDQufR06laS4jBu1oWILxt4/sSkzJdfkCTEMKg==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:
@@ -1944,7 +1944,7 @@ packages:
     dev: true
 
   /extend-shallow/2.0.1:
-    resolution: {integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=}
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extendable: 0.1.1
@@ -2330,7 +2330,7 @@ packages:
     dev: true
 
   /is-extendable/0.1.1:
-    resolution: {integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=}
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -3249,7 +3249,7 @@ packages:
     dev: true
 
   /sprintf-js/1.0.3:
-    resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: false
 
   /string-argv/0.3.1:
@@ -3294,7 +3294,7 @@ packages:
     dev: true
 
   /strip-bom-string/1.0.0:
-    resolution: {integrity: sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=}
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,15 @@ importers:
       '@antfu/eslint-config': ^0.25.2
       '@antfu/ni': ^0.16.3
       '@antfu/utils': ^0.5.2
-      '@mdit-vue/plugin-component': ^0.1.1
+      '@mdit-vue/plugin-component': ^0.6.0
+      '@mdit-vue/plugin-frontmatter': ^0.6.0
+      '@mdit-vue/types': ^0.6.0
       '@rollup/pluginutils': ^4.2.1
       '@types/markdown-it': ^12.2.3
       '@types/node': ^18.0.0
       '@vue/test-utils': ^2.0.1
       bumpp: ^8.2.1
       eslint: ^8.18.0
-      gray-matter: ^4.0.3
       markdown-it: ^13.0.1
       rollup: ^2.75.7
       tsup: ^6.1.2
@@ -23,10 +24,11 @@ importers:
       vitest: ^0.16.0
     dependencies:
       '@antfu/utils': 0.5.2
-      '@mdit-vue/plugin-component': 0.1.1
+      '@mdit-vue/plugin-component': 0.6.0
+      '@mdit-vue/plugin-frontmatter': 0.6.0
+      '@mdit-vue/types': 0.6.0
       '@rollup/pluginutils': 4.2.1
       '@types/markdown-it': 12.2.3
-      gray-matter: 4.0.3
       markdown-it: 13.0.1
     devDependencies:
       '@antfu/eslint-config': 0.25.2_b5e7v2qnwxfo6hmiq56u52mz3e
@@ -260,11 +262,24 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@mdit-vue/plugin-component/0.1.1:
-    resolution: {integrity: sha512-DC4OEZO737FbvwZxVToO2d9jprbQEs4lor7bylEBrPDYDds8pjRBUIx2BNc54X0effIopsZhq+b4gxkOHJOPNQ==}
+  /@mdit-vue/plugin-component/0.6.0:
+    resolution: {integrity: sha512-S/Dd0eoOipbUAMdJ6A7M20dDizJxbtGAcL6T1iiJ0cEzjTrHP1kRT421+JMGPL8gcdsrIxgVSW8bI/R6laqBtA==}
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
+    dev: false
+
+  /@mdit-vue/plugin-frontmatter/0.6.0:
+    resolution: {integrity: sha512-cRunxy0q1gcqxUHAAiV8hMKh2qZOTDKXt8YOWfWNtf7IzaAL0v/nCOfh+O7AsHRmyc25Th8sL3H85HKWnNJtdw==}
+    dependencies:
+      '@mdit-vue/types': 0.6.0
+      '@types/markdown-it': 12.2.3
+      gray-matter: 4.0.3
+      markdown-it: 13.0.1
+    dev: false
+
+  /@mdit-vue/types/0.6.0:
+    resolution: {integrity: sha512-2Gf6MkEmoHrvO/IJsz48T+Ns9lW17ReC1vdhtCUGSCv0fFCm/L613uu/hpUrHuT3jTQHP90LcbXTQB2w4L1G8w==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,9 +7,9 @@ importers:
       '@antfu/eslint-config': ^0.25.2
       '@antfu/ni': ^0.16.3
       '@antfu/utils': ^0.5.2
-      '@mdit-vue/plugin-component': ^0.7.0
-      '@mdit-vue/plugin-frontmatter': ^0.7.0
-      '@mdit-vue/types': ^0.7.0
+      '@mdit-vue/plugin-component': ^0.7.1
+      '@mdit-vue/plugin-frontmatter': ^0.7.1
+      '@mdit-vue/types': ^0.7.1
       '@rollup/pluginutils': ^4.2.1
       '@types/markdown-it': ^12.2.3
       '@types/node': ^18.0.0
@@ -24,9 +24,9 @@ importers:
       vitest: ^0.16.0
     dependencies:
       '@antfu/utils': 0.5.2
-      '@mdit-vue/plugin-component': 0.7.0
-      '@mdit-vue/plugin-frontmatter': 0.7.0
-      '@mdit-vue/types': 0.7.0
+      '@mdit-vue/plugin-component': 0.7.1
+      '@mdit-vue/plugin-frontmatter': 0.7.1
+      '@mdit-vue/types': 0.7.1
       '@rollup/pluginutils': 4.2.1
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
@@ -262,24 +262,24 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@mdit-vue/plugin-component/0.7.0:
-    resolution: {integrity: sha512-XKH99MRI2mkwTsKVKjrs8i/r4LGTrdX8p80aaH3gE42erlRTu41DOWJZ57HP4TQhSsENhY01DUS+rJlKcnWKfQ==}
+  /@mdit-vue/plugin-component/0.7.1:
+    resolution: {integrity: sha512-KkPgrZeNeRenfnFe8aNnE48IQ4rBHCaICQfzsjkRB4RlHce4lfCM5aG2Q+ct1/iJEzBr5uRhpPQMYwSEwv/k1Q==}
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
     dev: false
 
-  /@mdit-vue/plugin-frontmatter/0.7.0:
-    resolution: {integrity: sha512-L7VOyilYkHM8lX/de0I3huXPvo6FpQnsM9irHloCjxFjGWjQGQPVgKwlmuUiEnoszP91bGOcFazRUuESonZIxg==}
+  /@mdit-vue/plugin-frontmatter/0.7.1:
+    resolution: {integrity: sha512-4IdmU1UNnvJw3DcQVJFDPfUHb/k/VcMGKAINZ+DXJ6R2zP3eN92SrgR9zwIY0flKgRwXS4CQoiKJSd+0dvyU2A==}
     dependencies:
-      '@mdit-vue/types': 0.7.0
+      '@mdit-vue/types': 0.7.1
       '@types/markdown-it': 12.2.3
       gray-matter: 4.0.3
       markdown-it: 13.0.1
     dev: false
 
-  /@mdit-vue/types/0.7.0:
-    resolution: {integrity: sha512-9OlHbqAtKFvQ8lxeXEcLpwVQMZnlVAzSmSQ4OtlWPGGLnSUFNDQufR06laS4jBu1oWILxt4/sSkzJdfkCTEMKg==}
+  /@mdit-vue/types/0.7.1:
+    resolution: {integrity: sha512-3+JKRgCcrGDZsfikjkR5jXw0aPh6rYM9s9pwUhv6WwoHdU71za+TLXGQkb3wV/0vvxHFlkQRalXeINZZ1Q33GA==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
 import type MarkdownIt from 'markdown-it'
+import type { FrontmatterPluginOptions } from '@mdit-vue/plugin-frontmatter'
+import type { MarkdownItEnv } from '@mdit-vue/types'
 import type { FilterPattern } from '@rollup/pluginutils'
 
 /** a `<meta />` property in HTML is defined with the following name/values */
@@ -34,51 +36,6 @@ export interface Frontmatter {
   description?: string
   meta?: MetaProperty[]
   [key: string]: unknown
-}
-
-/**
- * Options for Graymatter parser [[Docs](https://github.com/jonschlinkert/gray-matter#options)]
- */
-export interface GraymatterOptions {
-  /**
-   * Extract an excerpt that directly follows front-matter, or is the
-   * first thing in the string if no front-matter exists.
-   *
-   * If set to excerpt: true, it will look for the frontmatter delimiter,
-   * --- by default and grab everything leading up to it.
-   *
-   * You can also set excerpt to a function. This function uses the 'file'
-   * and 'options' that were initially passed to gray-matter as parameters,
-   * so you can control how the excerpt is extracted from the content.
-   */
-  excerpt?: boolean | (() => string)
-
-  /**
-   * Define a custom separator to use for excerpts.
-   */
-  excerpt_separator?: string
-
-  /**
-   * Define custom engines for parsing and/or stringifying front-matter.
-   *
-   * Engines may either be an object with `parse` and (optionally) stringify
-   * methods, or a function that will be used for parsing only.
-   */
-  engines?: Record<string, () => any>
-
-  /**
-   * Define the engine to use for parsing front-matter.
-   *
-   * ```ts
-   * { language: 'toml' }
-   * ```
-   */
-  language?: string
-
-  /**
-   * Open and close delimiters can be passed in as an array of strings.
-   */
-  delimiters?: string | [string, string]
 }
 
 export interface Options {
@@ -189,7 +146,7 @@ export interface Options {
   /**
    * Options passed to [gray-matter](https://github.com/jonschlinkert/gray-matter#options)
    */
-  grayMatterOptions?: GraymatterOptions
+  grayMatterOptions?: FrontmatterPluginOptions['grayMatterOptions']
 
   /**
    * Class names for wrapper div
@@ -219,4 +176,8 @@ export interface Options {
 
 export interface ResolvedOptions extends Required<Options> {
   wrapperClasses: string
+}
+
+export interface MarkdownEnv extends MarkdownItEnv {
+  id: string
 }


### PR DESCRIPTION
`@mdit-vue/plugin-frontmatter` is built on `gray-matter`, but wrap the frontmatter / excerpt parsing inside markdown-it rendering workflow, and extract the result to the `env`.

Also, that plugin supports rendering exerpt to html, but I currently disable it to be consistent with our current behavior.

If this PR is accepted, I think we can go one step further to replace `grayMatterOptions` with `frontmatterOptions`, which accepts options for `@mdit-vue/plugin-frontmatter` (breaking change). Then users could enbale `renderExcerpt` by themselves.